### PR TITLE
Fixes for interfaces like iwm(4) and two new features.

### DIFF
--- a/wifind
+++ b/wifind
@@ -33,6 +33,7 @@ use warnings;
 
 my $ifconfig = '/sbin/ifconfig';
 my $head = "-chan -bssid -wpakey\n";
+my $global_opts = "";
 my $tail = "dhcp\n";
 
 sub slurp
@@ -53,6 +54,7 @@ sub write_hostname_if
 
 	my ($tmp_fh, $tmp_file) = tempfile('wifind.XXXXXXXXXX', DIR => '/etc');
 	print {$tmp_fh} $head;
+	print {$tmp_fh} $global_opts;
 	# set nwid, bssid, chan, lladdr
 	printf {$tmp_fh} 'nwid "%s"', $ap->{nwid};
 	printf {$tmp_fh} ' bssid "%s"', $ap->{bssid} if $ap->{bssid};

--- a/wifind
+++ b/wifind
@@ -78,14 +78,15 @@ pledge(qw( rpath wpath cpath fattr flock proc exec )) || die "Unable to pledge: 
 my $conf = decode_json(slurp '/etc/wifind.conf');
 my $wlan = $conf->{wlan};
 my $if = $conf->{if};
+$global_opts = $conf->{global_opts} if $conf->{global_opts};
 
 # initial scan
 open L, '-|', $ifconfig, $if, 'scan' or die "Can't open pipe: $!";
 
 pledge(qw( rpath wpath cpath fattr flock exec )) || die "Unable to pledge: $!";
 for (<L>) {
-	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (-\d+)dBm ([\w-]+) ([\w,-]+)\s*$/) {
-		my ($nwid, $chan, $bssid, $dbm, $mystery, $csv) =
+	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (\d+)% ([\w-]+) ([\w,-]+)\s*$/) {
+		my ($nwid, $chan, $bssid, $quality, $mystery, $csv) =
 		    ($1, $2, $3, $4, $5, $6);
 		my %cap = map { $_ => 1 } split(/,/, $csv);
 

--- a/wifind
+++ b/wifind
@@ -88,7 +88,7 @@ open L, '-|', $ifconfig, $if, 'scan' or die "Can't open pipe: $!";
 
 pledge(qw( rpath wpath cpath fattr flock exec )) || die "Unable to pledge: $!";
 for (<L>) {
-	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (?:-)?(\d+)(?:dBm)?(?:%) ([\w-]+) ([\w,-]+)\s*$/) {
+	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (?:-)?(\d+)(?:(?:dBm)|(?:%)) ([\w-]+) ([\w,-]+)\s*$/) {
 		my ($nwid, $chan, $bssid, $quality, $mystery, $csv) =
 		    ($1, $2, $3, $4, $5, $6);
 		my %cap = map { $_ => 1 } split(/,/, $csv);

--- a/wifind
+++ b/wifind
@@ -58,6 +58,7 @@ sub write_hostname_if
 	printf {$tmp_fh} ' bssid "%s"', $ap->{bssid} if $ap->{bssid};
 	printf {$tmp_fh} ' chan "%s"', $ap->{chan} if $ap->{chan};
 	printf {$tmp_fh} ' lladdr "%s"', $ap->{lladdr} if $ap->{lladdr};
+	printf {$tmp_fh} ' media %s', $ap->{media} if $ap->{media};
 	print {$tmp_fh} "\n";
 	# wpa needs to be set after nwid
 	printf {$tmp_fh} "wpakey \"%s\"\n", $ap->{wpakey} if $ap->{wpakey};

--- a/wifind
+++ b/wifind
@@ -88,7 +88,7 @@ open L, '-|', $ifconfig, $if, 'scan' or die "Can't open pipe: $!";
 
 pledge(qw( rpath wpath cpath fattr flock exec )) || die "Unable to pledge: $!";
 for (<L>) {
-	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (\d+)% ([\w-]+) ([\w,-]+)\s*$/) {
+	if (/^\s+nwid (.+) chan (\d+) bssid ([0-9a-f:]+) (?:-)?(\d+)(?:dBm)?(?:%) ([\w-]+) ([\w,-]+)\s*$/) {
 		my ($nwid, $chan, $bssid, $quality, $mystery, $csv) =
 		    ($1, $2, $3, $4, $5, $6);
 		my %cap = map { $_ => 1 } split(/,/, $csv);

--- a/wifind.conf.5
+++ b/wifind.conf.5
@@ -44,6 +44,7 @@ It also specifies the interface with which to scan and connect.
 .Bd -literal -offset indent
 {
    "if" : "iwn0",
+   "global_opts" : "lladdr random\n"
    "wlan" : [
       {
          "nwid" : "openwireless.org",

--- a/wifind.conf.5
+++ b/wifind.conf.5
@@ -47,7 +47,7 @@ It also specifies the interface with which to scan and connect.
    "wlan" : [
       {
          "nwid" : "openwireless.org",
-         "lladdr" : "random"
+         "media" : "mode 11g",
       },
       {
          "nwid" : "Corporate Network",


### PR DESCRIPTION
This fixes interfaces like iwm(4) which report in % vs dBm.

It also adds two features:
- The ability to specify `global_opts`, which can be used to set things like `lladdr random` for all APs. I am not sure if this is the right direction to go with this.. feels kinda dirty.
- The ability to specify media options per AP.

I can clean up the removal / add commit clutter if needed.
